### PR TITLE
Bug fix:  this PR solves 3 major bugs in the project

### DIFF
--- a/src/veins_libairmobisim/mobility/DroCIManager.cc
+++ b/src/veins_libairmobisim/mobility/DroCIManager.cc
@@ -437,7 +437,7 @@ void DroCIManager::deleteUAV(int deleteUavId)
     node->deleteModule();
 }
 
-void DroCIManager::insertUAV(int insertUavId, Coord startPosition, Coord endPosition, double startAngle, double speed)
+void DroCIManager::insertUAV(int insertUavId, Coord startPosition, Coord endPosition, double startAngle, int mobilityModel, double speed)
 {
 
     airmobisim::StartUav* startuav = new StartUav;
@@ -460,6 +460,7 @@ void DroCIManager::insertUAV(int insertUavId, Coord startPosition, Coord endPosi
 
     startuav->set_id(insertUavId);
     startuav->set_angle(startAngle);
+    startuav->set_mobilitymodel(mobilityModel);
     startuav->set_speed(speed);
 
     grpc::Status status = stub->InsertUAV(&clientcontext, *startuav, &empty);

--- a/src/veins_libairmobisim/mobility/DroCIManager.h
+++ b/src/veins_libairmobisim/mobility/DroCIManager.h
@@ -63,7 +63,7 @@ private:
     void processUavSubscription(std::string id, Coord p, double speed, double angle);
 
 public:
-    void insertUAV(int insertUavId, Coord startPosition, Coord endPosition, double startAngle, double speed);
+    void insertUAV(int insertUavId, Coord startPosition, Coord endPosition, double startAngle, int mobilityModel, double speed);
     void insertWaypoint(int uavId, double x, double y, double z, int index = -1);
 
     void updateWaypoints();

--- a/src/veins_libairmobisim/mobility/DroCIMobility.cc
+++ b/src/veins_libairmobisim/mobility/DroCIMobility.cc
@@ -73,7 +73,8 @@ void DroCIMobility::preInitialize(std::string external_id, const Coord& position
     this->heading = heading_new;
 
     Coord nextPos = calculateHostPosition(roadPosition);
-    nextPos.z = move.getStartPosition().z;
+    //set nextPos.z to UAV height
+    nextPos.z = position.z;
 
     move.setStart(nextPos);
     move.setDirectionByVector(heading.toCoord());
@@ -105,7 +106,7 @@ void DroCIMobility::changePosition()
     // ASSERT(lastUpdate != simTime());
 
     Coord nextPos = calculateHostPosition(roadPosition);
-    nextPos.z = move.getStartPosition().z;
+    
 
     // keep statistics (for current step)
     currentPosXVec.record(nextPos.x);
@@ -124,7 +125,7 @@ void DroCIMobility::changePosition()
         hostMod->getDisplayString().setTagArg("veins", 0, ". ");
     }
 
-    move.setStart(Coord(nextPos.x, nextPos.y, move.getStartPosition().z)); // keep z position
+    move.setStart(Coord(nextPos.x, nextPos.y, nextPos.z)); // z is UAV height 
     move.setDirectionByVector(heading.toCoord());
     move.setOrientationByVector(heading.toCoord());
     if (this->setHostSpeed) {
@@ -160,5 +161,5 @@ Coord DroCIMobility::calculateHostPosition(const Coord& vehiclePos) const
     else {
         corPos = vehiclePos;
     }
-    return vehiclePos;
+    return corPos;
 }

--- a/src/veins_libairmobisim/modules/UavInserter.cc
+++ b/src/veins_libairmobisim/modules/UavInserter.cc
@@ -77,9 +77,10 @@ void UavInserter::handleMessage(cMessage* msg)
         endPosition.y = 10;
         endPosition.z = 5;
         auto startAngle = 90;
+        int mobilityModel = 1; // 1 for linear mobility model and 2 for spline mobility model
         auto speed = 20;
         std::cout << "Add new UAV with: ID " << insertUavId << std::endl;
-        drociManager->insertUAV(insertUavId, startPosition, endPosition, startAngle, speed);
+        drociManager->insertUAV(insertUavId, startPosition, endPosition, startAngle, mobilityModel, speed);
 
         uavIdToDelete = insertUavId;
 
@@ -87,4 +88,13 @@ void UavInserter::handleMessage(cMessage* msg)
     else if (msg == deleteNewUavMsg) {
         drociManager->deleteUAV(uavIdToDelete);
     }
+}
+
+
+UavInserter::~UavInserter()
+{
+    cancelAndDelete(queryDataMsg);
+    cancelAndDelete(addWaypointMsg);
+    cancelAndDelete(insertNewUavMsg);
+    cancelAndDelete(deleteNewUavMsg);
 }

--- a/src/veins_libairmobisim/modules/UavInserter.h
+++ b/src/veins_libairmobisim/modules/UavInserter.h
@@ -33,7 +33,8 @@ class UavInserter : public cSimpleModule {
 protected:
     virtual void initialize(int stage) override;
     virtual void handleMessage(cMessage* msg) override;
-
+    ~UavInserter() override;
+    
     virtual int numInitStages() const
     {
         return 2;


### PR DESCRIPTION
Solves the following 3 issues:
1.  Solves segmentation fault at 100s simTime: Before deleting a UAV pointer cleanup is required by unregistering NIC: just like Veins does before deleting a module.
2. Mobility module does not set the  Z-coord to the UAV height; instead it always sets the Z coord to 0 just like veins does. 
3. While inserting a UAV, mobilityModel parameter was missing. This parameter is required by the python AirMobiSim-project to decide which mobility model to use: linear or spline mobility model